### PR TITLE
feat(payment_network): 決済ネットワークサービスを追加

### DIFF
--- a/memo.md
+++ b/memo.md
@@ -1,0 +1,119 @@
+AP2プロトコルにおける「Human Present Transaction」（ユーザー立ち会い型取引）のシーケンスフローについて、A2A通信をベースとした実装例に基づき、各ステップの具体的処理、通信詳細、および背景情報を以下の通りに解説します。
+
+このフローは、AIエージェント（ショッピングエージェント、マーチャントエージェント、資格情報プロバイダー）が**A2Aプロトコル**を用いて連携することを前提としています。
+
+### 背景情報：なぜこのフローが必要なのか
+
+既存の決済インフラは、自律的なAIエージェントによる取引を想定していません。AP2プロトコルは、エージェント取引における「信頼の危機」に対処するために設計されました。特に「Human Present Transaction」では、以下の目的のために詳細なシーケンスが必要です。
+
+1.  **検証可能な意図の確立 (Verifiable Intent)**: エージェントの「幻覚（Hallucination）」や誤解を防ぐため、ユーザーの購入意図と最終的な購入内容を、改ざん不可能なデジタル証明書（VDC）に紐づけて暗号署名する。
+2.  **明確な説明責任 (Clear Accountability)**: 取引にエラーや不正が発生した場合に、誰が責任を負うかを判断するための**監査可能なデジタル証拠（Cart Mandate, Intent Mandate）**を提供するため。
+3.  **セキュリティの確保**: 機密性の高い支払い情報（PCIデータ）が、ショッピングエージェントなどの非専門的なエンティティにアクセスされるのを防ぎ、**Credentials Provider (CP)** が排他的に管理するため。
+
+---
+
+### Human Present Transaction 詳細シーケンスフロー
+
+| ステップ | アクター | 処理内容と通信詳細 | 背景情報（なぜこの処理が必要か） |
+| :--- | :--- | :--- | :--- |
+| **1** | User → SA (Shopping Agent) | **Shopping Prompts (購買指示)**: ユーザーが、購買に必要なタスク（例：「このランニングシューズを買って」）を自然言語でSAに委任します。 | ユーザーがコマースタスクを開始し、SAに実行権限を委譲する初期段階です。 |
+| **2** | SA → User | **Intent Mandate Confirmation**: SAは、ユーザーの要求を理解した内容をユーザーに確認のために提示します。 | エージェントの理解がユーザーの意図と合致しているかを確認し、誤解釈（「Hallucination」）を防ぐためです。 |
+| **3** | User → SA | **Confirm (承認)**: ユーザーはSAの理解した内容を承認します。 | エージェントが次のステップに進むための初期の合意形成です。 |
+| **4, 5** | User → SA | **(Optional) CP / Shipping Address (CP/配送先住所の指定)**: ユーザーは、使用するCPや配送先住所を提供します。 | カートの価格を確定させるため、価格変動要因となる情報（配送先など）はCart Mandate作成前に確定させる必要があります。 |
+| **6** | SA → CP (Credential Provider) | **Get Payment Methods (支払い方法の取得)**: SAは、CPに対して支払いコンテキストを伝え、適用可能な支払い方法（参照または暗号化形式）を要求します。 | SAは、ユーザーが持つ支払い方法とマーチャントが受け入れる方法との互換性を確認し、最適な支払い方法の選択に役立てるためです。 |
+| **7** | CP → SA | **{ Payment Methods } (支払い方法リスト)**: CPは、利用可能な支払い方法をSAに返します。 | ユーザーが次のステップで、最終的な支払い方法を選択できるようにするためです。 |
+| **8** | SA → MA (Merchant Agent) | **Intent Mandate (意図証明書)**: SAは、ユーザーが署名した意図証明書（Intent Mandate）をMAに渡します。 | MAは、この意図証明書に基づき、ユーザーの要求を満たすカートの作成を開始します。 |
+| **9** | MA (内部処理) | **Create Cart Mandate (カート証明書の作成)**: MAは、Intent Mandateに基づき、SKU、価格、配送情報など、具体的な取引内容を定義した**Cart Mandate**を組み立てます。 | MAが具体的な注文内容を確定させる処理です。 |
+| **10** | MA → M (Merchant) | **Sign Cart Mandate (カート証明書への署名)**: MAは、作成したCart Mandateを**Merchant Entity (M)** に送り、署名を要求します。 | **マーチャントがこのカートを履行することを保証する**ためです。これにより、ユーザーはマーチャントが履行を確約したカートを確認できます。 |
+| **11** | M → MA | **{ Signed Cart Mandate } (署名済みカート証明書)**: マーチャントの署名が付与されたCart MandateがMAに返されます。 | マーチャント側での履行確約が完了したことを示します。 |
+| **12** | MA → SA | **{ Signed Cart Mandate }**: マーチャント署名済みのCart MandateがSAに渡されます。 | SAは、最終的な取引内容をユーザーに提示する準備が整います。 |
+| **13, 14** | SA ↔ CP | **Get user payment options / { payment options }**: SAがCPから最終的な支払いオプションを取得します。 | 最終的なカート内容（ステップ12）に基づいて、CPが最も適切な支払いオプションを絞り込むため、またはリスク要件（エージェント取引のセキュリティ/トークン化要件）を満たすステップアップが必要な場合に備えます。 |
+| **15a, 15b** | SA → User | **Show Cart Mandate / Payment Options Prompt (最終確認)**: SAは、マーチャントが保証した最終的なカート内容と支払いオプションを、信頼されたインターフェース上でユーザーに提示します。 | これは**不可欠な負荷担保ステップ**です。ユーザーが購入内容をすべて検証し、承認に進むためです。 |
+| **16** | User → SA | **Payment Method Selection (支払い方法の選択)**: ユーザーは提示されたオプションから、使用する特定の支払い方法を選択します。 | どの金融手段をチャージするかを確定させます。 |
+| **17** | SA → CP | **Get Payment Method Token (支払い方法トークンの取得)**: 選択された支払い方法のトークンをCPに要求します。 | 実際の支払いに使用するセキュアなトークンを取得し、**SAが機密性の高いPCIデータに触れるのを防ぎます**。 |
+| **18** | CP → SA | **{ Token } (トークン)**: CPはSAにトークンを返します。 | トークンは、Payment Mandateの構成要素となります。 |
+| **19** | SA (内部処理) | **Create Payment Mandate (決済証明書の作成)**: SAは、カートの内容、エージェントの関与、取引様式（Human Present）などの信号を含む**Payment Mandate**を作成します。 | このVDCは、取引承認メッセージとともにネットワーク/発行体に送られ、**エージェント取引であることを可視化する**役割を果たします。 |
+| **20** | SA → User | **Redirect to trusted device surface { PM, CM } (信頼されたデバイス画面へのリダイレクト)**: ユーザーは、購入を最終承認し、暗号署名を行うための信頼されたデバイス画面（例：ハードウェアキー、生体認証）にリダイレクトされます。 | ユーザーがハードウェア支援キーなどで署名し、**取引に対する否認不能な最終承認（Cart Mandateの署名）**を生成するためです。 |
+| **21** | User (デバイス処理) | **User confirms purchase & device creates attestation (ユーザー承認と証明の生成)**: ユーザーが購入を承認し、デバイスがその承認を示す暗号署名（Attestation）を生成します。 | **Verifiable Intent**を確立する最も重要なステップです。この署名が、紛争解決時の強力な証拠となります。 |
+| **22** | User → SA | **{ Attestation } (証明)**: ユーザーの暗号署名がSAに返されます。 | SAがこの署名をペイメントマシーンに渡すために必要です。 |
+| **23** | SA → CP | **Payment Mandate + Attestation**: SAは、完成したPayment MandateとユーザーのAttestationをCPに送信します。 | CPは、必要に応じてネットワークへのトークン化呼び出しを行い、必要な補足データと共に支払いエージェントトークンを要求します。 |
+| **24** | SA → MA | **Purchase { PM + Attestation } (購入の実行)**: SAはMAに対して、購入の実行を要求します。 | 注文を確定させ、決済フローをトリガーします。 |
+| **25** | MA → MPP (Merchant Payment Processor) | **Initiate payment { PM + Attestation } (支払い開始)**: MAは、取引の構成とネットワークへの送信をMPPに委任します。 | MPPは、発行体に対して承認要求を送信する責任を負うエンティティです。 |
+| **26** | MPP → CP | **Request payment credentials { Payment Mandate } (決済資格情報の要求)**: MPPは、決済処理に必要な資格情報（トークンなど）をCPに要求します。 | MPPがネットワークに送信する取引承認メッセージを構築するため、CPが管理するセキュアな支払い情報が必要です。 |
+| **27** | CP → MPP | **{ Payment Credentials } (決済資格情報)**: CPは、MPPに要求された決済資格情報を提供します。 | 支払いの実行に必要な情報がセキュアに渡されます。 |
+| **28** | MPP (内部処理) | **Process payment (決済処理)**: MPPは、標準的な取引承認メッセージ（**Payment Mandate**を付加したもの）を構築し、ネットワーク/発行体（Issuer）に送付します。 | ネットワーク/発行体は、Payment Mandateの信号（エージェントの関与など）を考慮して承認/拒否/チャレンジを決定します。 |
+| **29** | MPP → CP | **Payment receipt (決済レシート)**: 決済結果がCPに伝達されます。 | CPは、ユーザーの支払い管理エンティティとして、取引結果を確認・記録する必要があります。 |
+| **30** | MPP → MA | **Payment receipt**: 決済結果がMAに伝達されます。 | マーチャント側は、注文を履行（商品発送など）するために、支払い成功の確認が必要です。 |
+| **31** | MA → SA | **Payment receipt**: 決済結果がSAに伝達されます。 | SAはユーザーへの通知準備を行います。 |
+| **32** | SA → User | **Purchase completed + receipt (購入完了とレシート)**: SAはユーザーに購入が完了したこととレシートを通知します。 | 最終的なユーザー体験の完了です。 |
+
+### 通信プロトコルとペイロードの補足
+
+このフローは、エージェント間の通信に**A2A (Agent-to-Agent) プロトコル**を使用することを想定しています。A2Aは、エージェント間でセキュアかつ協調的な通信を行うためのオープンスタンダードです。
+
+特に重要なVDC（Verifiable Digital Credentials）のペイロード例は以下の通りです。これらはJSON形式の暗号署名されたオブジェクトとして交換されます。
+
+#### 1. Cart Mandate ペイロード (例)
+**目的**: ユーザーの購入意思を具体的な商品と金額に紐づけ、マーチャントが履行を確約した証拠を提供する。
+```json
+{
+  "contents": {
+    "id": "cart_shoes_123",
+    "user_signature_required": false, // 署名前はfalse
+    "payment_request": {
+      "method_data": [
+        {
+          "supported_methods": "CARD",
+          "data": {
+            "payment_processor_url": "http://example.com/pay" // 通信先/プロセッサ情報
+          }
+        }
+      ],
+      "details": {
+        "id": "order_shoes_123",
+        "displayItems": [
+          {
+            "label": "Nike Air Max 90",
+            "amount": { "currency": "USD", "value": 120.0 }
+          }
+        ],
+        "total": {
+          "label": "Total",
+          "amount": { "currency": "USD", "value": 120.0 }
+        }
+      }
+    }
+  },
+  "merchant_signature": "sig_merchant_shoes_abc1", // ステップ10, 11で付与
+  "timestamp": "2025-08-26T19:36:36.377022Z"
+}
+```
+
+#### 2. Payment Mandate ペイロード (例)
+**目的**: 決済ネットワーク/発行体に対し、この取引がAIエージェントによるものであること（AI Agent presence）と、その様式（Human Present v/s Not Present）を可視化する。
+```json
+{
+  "payment_details": {
+    "cart_mandate": "<user-signed hash of the cart mandate>", // Cart Mandateへの参照
+    "payment_request_id": "order_shoes_123",
+    "merchant_agent_card": {
+      "name": "MerchantAgent"
+    },
+    "payment_method": {
+      "supported_methods": "CARD",
+      "data": {
+        "token": "xyz789" // ステップ18で取得したトークン
+      }
+    },
+    "amount": {
+      "currency": "USD",
+      "value": 120.0
+    },
+    "risk_info": {
+      "device_imei": "abc123" // リスク信号を含む
+    },
+    "display_info": "<image bytes>"
+  },
+  "creation_time": "2025-08-26T19:36:36.377022Z"
+}
+```

--- a/v2/docker-compose.yml
+++ b/v2/docker-compose.yml
@@ -114,11 +114,14 @@ services:
       - AGENT_ID=did:ap2:agent:credential_provider
       - AP2_KEYS_DIRECTORY=/app/v2/keys
       - DATABASE_URL=sqlite+aiosqlite:////app/v2/data/credential_provider.db
+      - PAYMENT_NETWORK_URL=http://payment_network:8005
     networks:
       - ap2_network
     depends_on:
       init-keys:
         condition: service_completed_successfully
+      payment_network:
+        condition: service_started
     restart: unless-stopped
 
   # Payment Processor - 決済処理
@@ -144,6 +147,23 @@ services:
     depends_on:
       init-keys:
         condition: service_completed_successfully
+    restart: unless-stopped
+
+  # Payment Network - 決済ネットワーク（Agent Token発行）
+  payment_network:
+    build:
+      context: ..
+      dockerfile: v2/services/payment_network/Dockerfile
+    container_name: ap2_payment_network
+    ports:
+      - "8005:8005"
+    env_file:
+      - .env
+    environment:
+      - PYTHONUNBUFFERED=1
+      - NETWORK_NAME=DemoPaymentNetwork
+    networks:
+      - ap2_network
     restart: unless-stopped
 
   # Frontend - Next.js

--- a/v2/services/payment_network/Dockerfile
+++ b/v2/services/payment_network/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# システム依存関係のインストール
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# uvをインストール
+RUN pip install uv
+
+# プロジェクトファイルをコピー
+COPY v2/pyproject.toml /app/v2/
+COPY v2/README.md /app/v2/
+COPY v2/services/payment_network /app/v2/services/payment_network
+
+# 依存関係をインストール（uvを使用）
+RUN cd /app/v2 && uv pip install --system -e .
+
+# ワーキングディレクトリを設定
+WORKDIR /app/v2/services/payment_network
+
+# ポート公開
+EXPOSE 8005
+
+# サービス起動
+CMD ["python", "main.py"]

--- a/v2/services/payment_network/__init__.py
+++ b/v2/services/payment_network/__init__.py
@@ -1,0 +1,5 @@
+"""
+v2/services/payment_network/__init__.py
+
+Payment Network Service
+"""

--- a/v2/services/payment_network/main.py
+++ b/v2/services/payment_network/main.py
@@ -1,0 +1,28 @@
+"""
+v2/services/payment_network/main.py
+
+Payment Network Service - FastAPIエントリーポイント
+"""
+
+import logging
+import uvicorn
+from network import PaymentNetworkService
+
+# ロギング設定
+logging.basicConfig(
+    level=logging.INFO,
+    format='[%(asctime)s] %(levelname)s in %(name)s: %(message)s'
+)
+
+# Payment Network Serviceインスタンス作成
+payment_network = PaymentNetworkService(network_name="DemoPaymentNetwork")
+app = payment_network.app
+
+if __name__ == "__main__":
+    uvicorn.run(
+        "main:app",
+        host="0.0.0.0",
+        port=8005,
+        reload=False,
+        log_level="info"
+    )

--- a/v2/services/payment_network/network.py
+++ b/v2/services/payment_network/network.py
@@ -1,0 +1,305 @@
+"""
+v2/services/payment_network/network.py
+
+Payment Network Service実装
+
+決済ネットワークのスタブサービス：
+- Agent Tokenの発行（トークン化呼び出し）
+- トークン検証
+- 決済ネットワーク固有のロジック
+
+AP2仕様準拠：
+- Step 23: CPからのトークン化呼び出しを受け付ける
+- Agent Tokenを発行してCPに返却
+"""
+
+import sys
+import uuid
+import logging
+from pathlib import Path
+from typing import Dict, Any, Optional
+from datetime import datetime, timezone, timedelta
+import secrets
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+# 親ディレクトリを追加
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+logger = logging.getLogger(__name__)
+
+
+# ========================================
+# リクエスト/レスポンスモデル
+# ========================================
+
+class TokenizeRequest(BaseModel):
+    """
+    トークン化リクエスト（CPから受信）
+
+    AP2 Step 23: CPが決済ネットワークに送信するトークン化呼び出し
+    """
+    payment_mandate: Dict[str, Any]  # PaymentMandate オブジェクト
+    attestation: Optional[Dict[str, Any]] = None  # デバイス認証情報
+    payment_method_token: str  # CPが管理する支払い方法トークン
+    transaction_context: Optional[Dict[str, Any]] = None  # 追加のトランザクションデータ
+
+
+class TokenizeResponse(BaseModel):
+    """
+    トークン化レスポンス（CPに返却）
+    """
+    agent_token: str  # 決済ネットワークが発行するエージェントトークン
+    expires_at: str  # トークン有効期限（ISO 8601形式）
+    network_name: str  # ネットワーク名（例: "Visa", "Mastercard"）
+    token_type: str = "agent_token"  # トークンタイプ
+
+
+class VerifyTokenRequest(BaseModel):
+    """
+    トークン検証リクエスト
+    """
+    agent_token: str  # エージェントトークン
+
+
+class VerifyTokenResponse(BaseModel):
+    """
+    トークン検証レスポンス
+    """
+    valid: bool
+    token_info: Optional[Dict[str, Any]] = None
+    error: Optional[str] = None
+
+
+# ========================================
+# Payment Network Service
+# ========================================
+
+class PaymentNetworkService:
+    """
+    決済ネットワークサービス（スタブ実装）
+
+    実際の決済ネットワーク（Visa, Mastercard等）のスタブとして動作
+    - Agent Tokenの発行
+    - トークン検証
+
+    注意: このサービスは実際の決済ネットワークではなく、
+    デモ環境でのスタブ実装です。
+    """
+
+    def __init__(self, network_name: str = "DemoPaymentNetwork"):
+        self.network_name = network_name
+        self.app = FastAPI(
+            title=f"{network_name} - Payment Network Service",
+            description="AP2準拠の決済ネットワークスタブサービス",
+            version="1.0.0"
+        )
+
+        # トークンストア（Agent Token → トークン情報のマッピング）
+        # 本番環境ではRedis等のKVストアやデータベースを使用
+        self.agent_token_store: Dict[str, Dict[str, Any]] = {}
+
+        # エンドポイント登録
+        self.register_endpoints()
+
+        logger.info(f"[{self.network_name}] Payment Network Service initialized")
+
+    def register_endpoints(self):
+        """エンドポイントの登録"""
+
+        @self.app.get("/health")
+        async def health_check():
+            """ヘルスチェックエンドポイント"""
+            return {
+                "status": "healthy",
+                "service": "payment_network",
+                "network_name": self.network_name,
+                "timestamp": datetime.now(timezone.utc).isoformat()
+            }
+
+        @self.app.post("/network/tokenize", response_model=TokenizeResponse)
+        async def tokenize_payment(request: TokenizeRequest):
+            """
+            POST /network/tokenize - Agent Token発行
+
+            AP2 Step 23: Credential Providerからのトークン化呼び出し
+
+            処理フロー:
+            1. PaymentMandateとattestationを検証
+            2. 支払い方法トークンを検証
+            3. Agent Tokenを生成（暗号学的に安全なトークン）
+            4. トークンストアに保存
+            5. Agent Tokenを返却
+
+            リクエスト:
+            {
+              "payment_mandate": {...},
+              "attestation": {...},
+              "payment_method_token": "tok_xxx",
+              "transaction_context": {...}
+            }
+
+            レスポンス:
+            {
+              "agent_token": "agent_tok_xxx",
+              "expires_at": "2025-10-18T12:34:56Z",
+              "network_name": "DemoPaymentNetwork",
+              "token_type": "agent_token"
+            }
+            """
+            try:
+                payment_mandate = request.payment_mandate
+                payment_method_token = request.payment_method_token
+
+                logger.info(
+                    f"[{self.network_name}] Received tokenization request: "
+                    f"payment_mandate_id={payment_mandate.get('id')}, "
+                    f"payment_method_token={payment_method_token[:20]}..."
+                )
+
+                # PaymentMandate検証（スタブ実装）
+                if not payment_mandate.get("id"):
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Missing payment_mandate.id"
+                    )
+
+                # 支払い方法トークン検証（スタブ実装）
+                if not payment_method_token.startswith("tok_"):
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Invalid payment_method_token format"
+                    )
+
+                # Agent Token生成（暗号学的に安全）
+                # 実際の決済ネットワークでは、ネットワーク固有のトークン化ロジックを実装
+                now = datetime.now(timezone.utc)
+                expires_at = now + timedelta(hours=1)  # 1時間有効
+
+                # secrets.token_urlsafe()を使用（cryptographically strong random）
+                random_bytes = secrets.token_urlsafe(32)  # 32バイト = 256ビット
+                agent_token = f"agent_tok_{self.network_name.lower()}_{uuid.uuid4().hex[:8]}_{random_bytes[:24]}"
+
+                # トークンストアに保存
+                self.agent_token_store[agent_token] = {
+                    "payment_mandate_id": payment_mandate.get("id"),
+                    "payment_method_token": payment_method_token,
+                    "payer_id": payment_mandate.get("payer_id"),
+                    "amount": payment_mandate.get("amount"),
+                    "issued_at": now.isoformat(),
+                    "expires_at": expires_at.isoformat(),
+                    "network_name": self.network_name,
+                    "attestation_verified": request.attestation is not None
+                }
+
+                logger.info(
+                    f"[{self.network_name}] Issued Agent Token: {agent_token[:32]}..., "
+                    f"expires_at={expires_at.isoformat()}"
+                )
+
+                return TokenizeResponse(
+                    agent_token=agent_token,
+                    expires_at=expires_at.isoformat().replace('+00:00', 'Z'),
+                    network_name=self.network_name,
+                    token_type="agent_token"
+                )
+
+            except HTTPException:
+                raise
+            except Exception as e:
+                logger.error(f"[{self.network_name}] Tokenization error: {e}", exc_info=True)
+                raise HTTPException(status_code=500, detail=str(e))
+
+        @self.app.post("/network/verify-token", response_model=VerifyTokenResponse)
+        async def verify_token(request: VerifyTokenRequest):
+            """
+            POST /network/verify-token - Agent Token検証
+
+            処理フロー:
+            1. Agent Tokenをトークンストアから取得
+            2. 有効期限を確認
+            3. トークン情報を返却
+
+            リクエスト:
+            {
+              "agent_token": "agent_tok_xxx"
+            }
+
+            レスポンス:
+            {
+              "valid": true,
+              "token_info": {
+                "payment_mandate_id": "...",
+                "payer_id": "...",
+                "amount": {...},
+                "network_name": "DemoPaymentNetwork"
+              }
+            }
+            """
+            try:
+                agent_token = request.agent_token
+
+                logger.info(f"[{self.network_name}] Verifying Agent Token: {agent_token[:32]}...")
+
+                # トークンストアから取得
+                token_data = self.agent_token_store.get(agent_token)
+                if not token_data:
+                    logger.warning(f"[{self.network_name}] Agent Token not found: {agent_token[:32]}...")
+                    return VerifyTokenResponse(
+                        valid=False,
+                        error="Agent Token not found"
+                    )
+
+                # 有効期限確認
+                expires_at = datetime.fromisoformat(token_data["expires_at"])
+                if datetime.now(timezone.utc) > expires_at:
+                    logger.warning(f"[{self.network_name}] Agent Token expired: {agent_token[:32]}...")
+                    # 期限切れトークンを削除
+                    del self.agent_token_store[agent_token]
+                    return VerifyTokenResponse(
+                        valid=False,
+                        error="Agent Token expired"
+                    )
+
+                logger.info(
+                    f"[{self.network_name}] Agent Token valid: "
+                    f"payment_mandate_id={token_data.get('payment_mandate_id')}"
+                )
+
+                return VerifyTokenResponse(
+                    valid=True,
+                    token_info={
+                        "payment_mandate_id": token_data.get("payment_mandate_id"),
+                        "payer_id": token_data.get("payer_id"),
+                        "amount": token_data.get("amount"),
+                        "network_name": token_data.get("network_name"),
+                        "issued_at": token_data.get("issued_at"),
+                        "expires_at": token_data.get("expires_at")
+                    }
+                )
+
+            except Exception as e:
+                logger.error(f"[{self.network_name}] Token verification error: {e}", exc_info=True)
+                raise HTTPException(status_code=500, detail=str(e))
+
+        @self.app.get("/network/info")
+        async def network_info():
+            """
+            GET /network/info - ネットワーク情報取得
+
+            レスポンス:
+            {
+              "network_name": "DemoPaymentNetwork",
+              "supported_payment_methods": ["card"],
+              "tokenization_enabled": true,
+              "agent_transactions_supported": true
+            }
+            """
+            return {
+                "network_name": self.network_name,
+                "supported_payment_methods": ["card", "digital_wallet"],
+                "tokenization_enabled": True,
+                "agent_transactions_supported": True,
+                "timestamp": datetime.now(timezone.utc).isoformat()
+            }

--- a/v2/services/payment_network/test_network.py
+++ b/v2/services/payment_network/test_network.py
@@ -1,0 +1,90 @@
+"""
+v2/services/payment_network/test_network.py
+
+Payment Network Serviceのテスト
+"""
+
+import sys
+from pathlib import Path
+import asyncio
+import httpx
+
+# 親ディレクトリを追加
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+
+async def test_payment_network():
+    """決済ネットワークサービスの動作テスト"""
+
+    base_url = "http://localhost:8005"
+
+    async with httpx.AsyncClient() as client:
+        # 1. ヘルスチェック
+        print("\n=== 1. ヘルスチェック ===")
+        response = await client.get(f"{base_url}/health")
+        print(f"Status: {response.status_code}")
+        print(f"Response: {response.json()}")
+        assert response.status_code == 200
+
+        # 2. ネットワーク情報取得
+        print("\n=== 2. ネットワーク情報取得 ===")
+        response = await client.get(f"{base_url}/network/info")
+        print(f"Status: {response.status_code}")
+        print(f"Response: {response.json()}")
+        assert response.status_code == 200
+
+        # 3. Agent Token発行（トークン化呼び出し）
+        print("\n=== 3. Agent Token発行 ===")
+        tokenize_request = {
+            "payment_mandate": {
+                "id": "pm_test_001",
+                "payer_id": "user_demo_001",
+                "amount": {
+                    "value": "10000.00",
+                    "currency": "JPY"
+                }
+            },
+            "attestation": {
+                "type": "passkey",
+                "verified": True
+            },
+            "payment_method_token": "tok_visa_4242",
+            "transaction_context": {
+                "test": True
+            }
+        }
+
+        response = await client.post(
+            f"{base_url}/network/tokenize",
+            json=tokenize_request
+        )
+        print(f"Status: {response.status_code}")
+        data = response.json()
+        print(f"Response: {data}")
+        assert response.status_code == 200
+        assert "agent_token" in data
+
+        agent_token = data["agent_token"]
+
+        # 4. Agent Token検証
+        print("\n=== 4. Agent Token検証 ===")
+        verify_request = {
+            "agent_token": agent_token
+        }
+
+        response = await client.post(
+            f"{base_url}/network/verify-token",
+            json=verify_request
+        )
+        print(f"Status: {response.status_code}")
+        data = response.json()
+        print(f"Response: {data}")
+        assert response.status_code == 200
+        assert data["valid"] is True
+        assert data["token_info"]["payment_mandate_id"] == "pm_test_001"
+
+        print("\n✅ すべてのテストが成功しました！")
+
+
+if __name__ == "__main__":
+    asyncio.run(test_payment_network())


### PR DESCRIPTION
決済ネットワークのスタブサービスを実装し、エージェントトークンの発行と検証を行うAPIを提供します。
- トークン化リクエストとレスポンスモデルを定義
- FastAPIを使用してエンドポイントを登録
- ヘルスチェック機能を追加
- エージェントトークンの生成と検証ロジックを実装